### PR TITLE
Add landscape diagram for accessing civil legal aid

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.png filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 The documentation here uses the [C4 model][c4model] by [Simon Brown][simonbrown].
 We use the [FC4 toolset][fc4-toolset] to normalise the source of C4 diagrams authored with [Structurizr Express][se].
 
+## Requirements
+
+Image files in this repository are tracked through [Git Large File Storage][git-lfs].
+Please install it by following the [site instructions][git-lfs].
+
 ## Structure
 
 Legal Aid Agency is divided into the following service areas, with their respective locations in the repository:
@@ -22,6 +27,7 @@ Legal Aid Agency is divided into the following service areas, with their respect
 
 
 [se]: https://structurizr.com/help/express
+[git-lfs]: https://git-lfs.github.com/
 [c4model]: https://c4model.com/
 [simonbrown]: http://simonbrown.je/
 [fc4-toolset]: https://fundingcircle.github.io/fc4-framework/methodology/toolset.html

--- a/diagrams/get-access/civil-legal-aid-system-landscape.key.png
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.key.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:949708d593c45fae9f5fc9198e259b278fe4cb9d83e73908ccc192b3de9963a2
+size 127925

--- a/diagrams/get-access/civil-legal-aid-system-landscape.png
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71c1e29d31e58afa8094ca83d4b9bc05013b51116b533159b743fa99458b032a
+size 626153

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -1,0 +1,134 @@
+links:
+  The FC4 Framework: https://fundingcircle.github.io/fc4-framework/
+  Structurizr Express: https://structurizr.com/express
+---
+type: System Landscape
+scope: Accessing Civil Legal Aid
+description: Describes the components related to accessing civil legal aid for members of the public
+
+elements:
+- type: Person
+  name: Case Handler
+  position: '1900,480'
+- type: Person
+  name: Citizen
+  tags: external
+  position: '2700,80'
+- type: Person
+  name: Civil Legal Provider
+  tags: external
+  position: '1100,80'
+- type: Person
+  name: Manager Information Analyst
+  position: '1900,1920'
+- type: Software System
+  name: Case Handler Identity Database
+  tags: database
+  position: '100,820'
+- type: Software System
+  name: Civil Legal Advice
+  description: (CLA_public)
+  tags: web
+  position: '2700,1080'
+- type: Software System
+  name: Civil Legal Advice Case Handler
+  description: (CLA_frontend and CLA_backend)
+  tags: web
+  position: '1100,1080'
+- type: Software System
+  name: Contract Work Assessment
+  description: (CWA) Source of truth for Civil Legal Provider details (amongst other responsibilities)
+  position: '100,1980'
+- type: Software System
+  name: Data Warehouse
+  description: (OBIEE) Collects data related to common concepts from various sources
+  tags: database
+  position: '1100,1980'
+- type: Software System
+  name: Find a Legal Adviser
+  description: (FALA)
+  tags: web
+  position: '2700,1520'
+- type: Software System
+  name: Legal Adviser API
+  description: (laa-legal-adviser-api)
+  position: '2700,1980'
+- type: Software System
+  name: Provider Case Handler
+  tags: external
+  position: '110,120'
+- type: Software System
+  name: Provider Identity Database
+  tags: database
+  position: '110,1380'
+
+relationships:
+- source: Case Handler
+  description: Talks to
+  destination: Citizen
+- source: Case Handler
+  description: Checks eligibility and data of incoming legal aid requests
+  destination: Civil Legal Advice Case Handler
+- source: Case Handler
+  description: Talks to
+  destination: Civil Legal Provider
+- source: Citizen
+  description: Looking for legal aid
+  destination: Civil Legal Advice
+- source: Citizen
+  description: Talks to
+  destination: Civil Legal Provider
+- source: Civil Legal Advice Case Handler
+  description: uses
+  destination: Case Handler Identity Database
+- source: Civil Legal Advice Case Handler
+  description: uses
+  destination: Provider Identity Database
+- source: Civil Legal Advice
+  description: Registers incoming legal aid requests
+  destination: Civil Legal Advice Case Handler
+- source: Civil Legal Advice
+  description: Get Civil Legal Provider details if necessary
+  destination: Find a Legal Adviser
+- source: Civil Legal Provider
+  description: Logs in and uploads work report CSV to
+  destination: Civil Legal Advice Case Handler
+- source: Civil Legal Provider
+  description: Manages work via
+  destination: Provider Case Handler
+- source: Contract Work Assessment
+  description: Periodically updates Civil Legal Provider details
+  destination: Data Warehouse
+- source: Data Warehouse
+  description: Periodically updates Civil Legal Provider details
+  destination: Civil Legal Advice Case Handler
+- source: Find a Legal Adviser
+  description: uses
+  destination: Legal Adviser API
+- source: Manager Information Analyst
+  description: Periodically downloads Civil Legal Provider details
+  destination: Data Warehouse
+- source: Manager Information Analyst
+  description: Periodically updates Civil Legal Provider details
+  destination: Legal Adviser API
+
+styles:
+- type: element
+  tag: Element
+  background: '#5a5c92'
+  color: '#ffffff'
+- type: element
+  tag: Person
+  shape: Person
+- type: element
+  tag: database
+  shape: Cylinder
+- type: element
+  tag: external
+  background: '#28a197'
+  color: '#ffffff'
+- type: element
+  tag: web
+  shape: WebBrowser
+
+size: A4_Landscape


### PR DESCRIPTION
## What does this pull request do?

**Adds "Accessing Civil Legal Aid" diagram**
Adds `diagrams/get-access/civil-legal-aid-system-landscape.yaml` diagram, titled "Accessing Civil Legal Aid". The aim of the diagram is to present a view of which people and what software systems are involved in citizens and residents accessing civil legal aid.

![civil-legal-aid-system-landscape](https://user-images.githubusercontent.com/1526295/41851503-feae507a-787f-11e8-8179-bb6dd64df1cd.png)

**Colours used on the diagram (copied from the readme)**
- Legal Aid Agency software systems, people and elements use the "Ministry of Justice" websafe colour (`#5a5c92`).
- Software systems, people and elements outside the UK Government use `#28a197`.

## Any other changes which would benefit highlighting?

**Git LFS**
Since this is the first diagram in this repository and we are going to commit high-resolution lossless images, this pull request also sets up Git LFS.