### PR TITLE
Assign code ownership to Legal Aid Agency architects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @ministryofjustice/laa-technical-architects


### PR DESCRIPTION
## What does this pull request do?

Adds a [CODEOWNERS file](https://help.github.com/articles/about-codeowners/) that assigns ownership to @ministryofjustice/laa-technical-architects for enforced reviews.