### PR TITLE
Add CCMS EBS System Context diagram

### DIFF
--- a/diagrams/ccms-ebs-system-context.key.png
+++ b/diagrams/ccms-ebs-system-context.key.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e8044f5e61df81278b0803b0a3911a7737de06c69f04d46566e88cd927e7cc9
+size 55838

--- a/diagrams/ccms-ebs-system-context.png
+++ b/diagrams/ccms-ebs-system-context.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65772f3111c3f7b322caeffe809c59b29921b2867d023141408156239dd8e8f8
+size 374610

--- a/diagrams/ccms-ebs-system-context.yaml
+++ b/diagrams/ccms-ebs-system-context.yaml
@@ -1,0 +1,85 @@
+links:
+  The FC4 Framework: https://fundingcircle.github.io/fc4-framework/
+  Structurizr Express: https://structurizr.com/express
+---
+type: System Context
+scope: CCMS eBusiness Suite
+description: The system context diagram for CCMS eBusiness Suite. Deliberately omits communication details such as SOA and Information HUB
+
+elements:
+- type: Person
+  name: Caseworker
+  description: Civil Legal Aid Caseworker
+  position: '1025,50'
+- type: Software System
+  name: CCMS Financials
+  description: (Oracle Financials) Accounting functions for the legal aid fund
+  position: '1000,1200'
+- type: Software System
+  name: CCMS Provider UI
+  description: Civil legal aid application forms
+  position: '200,700'
+- type: Software System
+  name: CCMS eBusiness Suite
+  description: Handles Civil Legal Aid applications. (CCMS = Client and Cost Management System.
+  position: '1000,700'
+- type: Software System
+  name: CIS
+  description: Civil / family certified work, exceptional cases, housing court duty, very high cost. Invoices pass through it.
+  position: '1900,200'
+- type: Software System
+  name: Central Print
+  description: Civil legal aid application forms
+  position: '200,1200'
+- type: Software System
+  name: Contract Work Assessment
+  description: Holds list of contracted legal providers
+  position: '1900,700'
+- type: Software System
+  name: LAA Benefit Checker
+  description: Confirms if individual is in receipt of a passported benefit by calling DWP benefit checker service
+  position: '1900,1200'
+
+relationships:
+- source: CCMS Provider UI
+  description: Submits form results via SOA
+  destination: CCMS eBusiness Suite
+- source: CCMS eBusiness Suite
+  destination: CCMS Financials
+- source: CCMS eBusiness Suite
+  description: Correspondence and Certificates
+  destination: Central Print
+- source: CCMS eBusiness Suite
+  description: Passported benefit check
+  destination: LAA Benefit Checker
+- source: CIS
+  description: Invoices, Payments, Contributions
+  destination: CCMS eBusiness Suite
+- source: Caseworker
+  description: uses
+  destination: CCMS eBusiness Suite
+- source: Contract Work Assessment
+  description: Provider, User, Bank sync. Contract lookup
+  destination: CCMS eBusiness Suite
+
+styles:
+- type: element
+  tag: Element
+  background: '#5a5c92'
+  color: '#ffffff'
+- type: element
+  tag: Person
+  shape: Person
+- type: element
+  tag: database
+  shape: Cylinder
+- type: element
+  tag: external
+  background: '#28a197'
+  color: '#ffffff'
+- type: element
+  tag: web
+  shape: WebBrowser
+
+size: A5_Landscape
+


### PR DESCRIPTION
## What

I started describing CCMS by drawing the system context for eBusiness Suite (EBS).

The responsibilities of the main parts of CCMS (EBS, Provider UI, and Financials) are distinct enough to separate them out even at this level of detail.

This lists the main collaborators with CCMS EBS, but excluding SOA and Hub for clarity (they don't add a huge amount at this level of detail. I don't know enough about EDRM to include it yet.

## Suggested review feedback

- Check the names & relationships match reality
- Feedback on clarity
- Bonus: provide additional context on EDRM
- Bonus: check the yaml I've committed generates the diagrams I've committed