### PR TITLE
Update access to civil legal aid landscape diagram

### DIFF
--- a/diagrams/get-access/civil-legal-aid-system-landscape.key.png
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.key.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:949708d593c45fae9f5fc9198e259b278fe4cb9d83e73908ccc192b3de9963a2
-size 127925
+oid sha256:935ad59ff1d39761e29908ee4e84c7f8d595c9cc217f94ae41f9f435d28d9468
+size 130182

--- a/diagrams/get-access/civil-legal-aid-system-landscape.png
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71c1e29d31e58afa8094ca83d4b9bc05013b51116b533159b743fa99458b032a
-size 626153
+oid sha256:922c6d6027ce1033fd2ed0a1a918ca14af1eda2ff4e6b11a92292ee9ea80a0f0
+size 1059408

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -28,7 +28,7 @@ elements:
 - type: Software System
   name: Check Legal Aid
   description: (CLA_public) https://checklegalaid.service.gov.uk/
-  tags: web
+  tags: web,public
   position: '2500,900'
 - type: Software System
   name: Civil Legal Advice Backend
@@ -50,8 +50,8 @@ elements:
   position: '1100,2000'
 - type: Software System
   name: Find a Legal Adviser
-  description: (FALA)
-  tags: web
+  description: (FALA) https://find-legal-advice.justice.gov.uk/
+  tags: web,public
   position: '3000,900'
 - type: Software System
   name: Legal Adviser API
@@ -137,6 +137,10 @@ styles:
   tag: external
   background: '#28a197'
   color: '#ffffff'
+- type: element
+  tag: public
+  background: '#b2b3cf'
+  color: '#22245f'
 - type: element
   tag: web
   shape: WebBrowser

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -15,7 +15,7 @@ elements:
   tags: external
   position: '3325,50'
 - type: Person
-  name: Civil Legal Provider
+  name: Civil Legal Advice Specialist Provider
   tags: external
   position: '1025,50'
 - type: Person
@@ -41,7 +41,7 @@ elements:
   position: '1000,700'
 - type: Software System
   name: Contract Work Assessment
-  description: (CWA) Source of truth for Civil Legal Provider details (amongst other responsibilities)
+  description: (CWA) Source of truth for Civil Legal Advice Specialist Provider details (amongst other responsibilities)
   position: '1000,2800'
 - type: Software System
   name: Data Warehouse
@@ -83,7 +83,7 @@ relationships:
   destination: Civil Legal Advice Case Handling System
 - source: Case Handler
   description: Talks to
-  destination: Civil Legal Provider
+  destination: Civil Legal Advice Specialist Provider
 - source: Check Legal Aid
   description: Registers incoming legal aid requests
   destination: Civil Legal Advice Backend
@@ -95,7 +95,7 @@ relationships:
   destination: Check Legal Aid
 - source: Citizen
   description: Talks to
-  destination: Civil Legal Provider
+  destination: Civil Legal Advice Specialist Provider
 - source: Citizen
   description: Looking for nearby legal advisers
   destination: Find a Legal Adviser
@@ -108,32 +108,32 @@ relationships:
 - source: Civil Legal Advice Case Handling System
   description: Registers and updates incoming legal aid requests
   destination: Civil Legal Advice Backend
-- source: Civil Legal Provider
+- source: Civil Legal Advice Specialist Provider
   description: Logs in and uploads work report CSV to
   destination: Civil Legal Advice Case Handling System
-- source: Civil Legal Provider
+- source: Civil Legal Advice Specialist Provider
   description: Manages work via
   destination: Provider Case Handler
 - source: Contract Work Assessment
-  description: Periodically updates Civil Legal Provider details
+  description: Periodically updates Civil Legal Advice Specialist Provider details
   destination: Hub Job
 - source: Find a Legal Adviser
   description: uses
   destination: Legal Adviser API
 - source: Hub Job
-  description: Periodically updates Civil Legal Provider details
+  description: Periodically updates Civil Legal Advice Specialist Provider details
   destination: Data Warehouse
 - source: Hub Job
-  description: Periodically updates Civil Legal Provider details
+  description: Periodically updates Civil Legal Advice Specialist Provider details
   destination: Provider Identity Database
 - source: Legal Adviser API
   description: uses
   destination: postcodes.io
 - source: Management Information Team
-  description: Periodically downloads Civil Legal Provider details
+  description: Periodically downloads Civil Legal Advice Specialist Provider details
   destination: Data Warehouse
 - source: Management Information Team
-  description: Periodically updates Civil Legal Provider details
+  description: Periodically updates Civil Legal Advice Specialist Provider details
   destination: Legal Adviser API
 
 styles:

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -57,7 +57,7 @@ elements:
   name: Hub Job
   position: '2300,2800'
 - type: Software System
-  name: Legal Adviser API
+  name: Legal Adviser Location Search API
   description: (laa-legal-adviser-api)
   position: '3300,1300'
 - type: Software System
@@ -89,7 +89,7 @@ relationships:
   destination: Civil Legal Advice Backend
 - source: Check Legal Aid
   description: uses
-  destination: Legal Adviser API
+  destination: Legal Adviser Location Search API
 - source: Citizen
   description: Looking for legal aid
   destination: Check Legal Aid
@@ -119,14 +119,14 @@ relationships:
   destination: Hub Job
 - source: Find a Legal Adviser
   description: uses
-  destination: Legal Adviser API
+  destination: Legal Adviser Location Search API
 - source: Hub Job
   description: Periodically updates Civil Legal Advice Specialist Provider details
   destination: Data Warehouse
 - source: Hub Job
   description: Periodically updates Civil Legal Advice Specialist Provider details
   destination: Provider Identity Database
-- source: Legal Adviser API
+- source: Legal Adviser Location Search API
   description: uses
   destination: postcodes.io
 - source: Management Information Team
@@ -134,7 +134,7 @@ relationships:
   destination: Data Warehouse
 - source: Management Information Team
   description: Periodically updates Civil Legal Advice Specialist Provider details
-  destination: Legal Adviser API
+  destination: Legal Adviser Location Search API
 
 styles:
 - type: element

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -36,8 +36,8 @@ elements:
   position: '1900,1300'
 - type: Software System
   name: Civil Legal Advice Case Handling System
-  description: (CLA_frontend)
-  tags: web
+  description: (CLA_frontend) https://cases.civillegaladvice.service.gov.uk/
+  tags: web,public
   position: '1000,700'
 - type: Software System
   name: Contract Work Assessment

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -119,6 +119,13 @@ relationships:
 - source: Contract Analyst
   description: Periodically downloads reports
   destination: Civil Legal Advice Case Handling System
+  vertices:
+  - '1300,1150'
+- source: Contract Analyst
+  description: Manages provider users
+  destination: Civil Legal Advice Case Handling System
+  vertices:
+  - '1300,1000'
 - source: Contract Work Assessment
   description: Periodically updates Civil Legal Advice Specialist Provider details
   destination: Hub Job

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -67,7 +67,7 @@ elements:
   description: (laa-legal-adviser-api)
   position: '3300,1300'
 - type: Software System
-  name: Provider Case Handler
+  name: Provider's Case Handling System
   tags: external
   position: '100,100'
 - type: Software System
@@ -119,7 +119,7 @@ relationships:
   destination: Civil Legal Advice Case Handling System
 - source: Civil Legal Advice Specialist Provider
   description: Manages work via
-  destination: Provider Case Handler
+  destination: Provider's Case Handling System
 - source: Contract Analyst
   description: Periodically downloads reports
   destination: Civil Legal Advice Case Handling System

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -9,58 +9,58 @@ description: Describes the components related to accessing civil legal aid for m
 elements:
 - type: Person
   name: Case Handler
-  position: '1900,480'
+  position: '1925,450'
 - type: Person
   name: Citizen
   tags: external
-  position: '2700,80'
+  position: '2725,50'
 - type: Person
   name: Civil Legal Provider
   tags: external
-  position: '1100,80'
+  position: '1125,50'
 - type: Person
   name: Management Information Analyst
-  position: '1900,1960'
+  position: '1925,1950'
 - type: Software System
   name: Case Handler Identity Database
   tags: database
-  position: '100,820'
+  position: '100,800'
 - type: Software System
   name: Civil Legal Advice
   description: (CLA_public)
   tags: web
-  position: '2700,1080'
+  position: '2700,1000'
 - type: Software System
   name: Civil Legal Advice Case Handler
   description: (CLA_frontend and CLA_backend)
   tags: web
-  position: '1100,1080'
+  position: '1100,1000'
 - type: Software System
   name: Contract Work Assessment
   description: (CWA) Source of truth for Civil Legal Provider details (amongst other responsibilities)
-  position: '100,1980'
+  position: '100,2000'
 - type: Software System
   name: Data Warehouse
   description: (OBIEE) Collects data related to common concepts from various sources
   tags: database
-  position: '1100,1980'
+  position: '1100,2000'
 - type: Software System
   name: Find a Legal Adviser
   description: (FALA)
   tags: web
-  position: '2700,1520'
+  position: '2700,1500'
 - type: Software System
   name: Legal Adviser API
   description: (laa-legal-adviser-api)
-  position: '2700,1980'
+  position: '2700,2000'
 - type: Software System
   name: Provider Case Handler
   tags: external
-  position: '110,120'
+  position: '100,100'
 - type: Software System
   name: Provider Identity Database
   tags: database
-  position: '110,1380'
+  position: '100,1400'
 
 relationships:
 - source: Case Handler

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -20,7 +20,7 @@ elements:
   position: '1025,50'
 - type: Person
   name: Management Information Analyst
-  position: '3325,1950'
+  position: '3025,1950'
 - type: Software System
   name: Case Handler Identity Database
   tags: database
@@ -29,11 +29,11 @@ elements:
   name: Check Legal Aid
   description: (CLA_public) https://checklegalaid.service.gov.uk/
   tags: web,public
-  position: '2900,700'
+  position: '3000,700'
 - type: Software System
   name: Civil Legal Advice Backend
   description: (CLA_backend)
-  position: '2000,1400'
+  position: '2000,1300'
 - type: Software System
   name: Civil Legal Advice Case Handling System
   description: (CLA_frontend) https://cases.civillegaladvice.service.gov.uk/
@@ -47,19 +47,19 @@ elements:
   name: Data Warehouse
   description: (OBIEE) Collects data related to common concepts from various sources
   tags: database
-  position: '3300,2800'
+  position: '3000,2800'
 - type: Software System
   name: Find a Legal Adviser
   description: (FALA) https://find-legal-advice.justice.gov.uk/
   tags: web,public
-  position: '3700,700'
+  position: '3600,700'
 - type: Software System
   name: Hub Job
-  position: '2000,2800'
+  position: '2300,2800'
 - type: Software System
   name: Legal Adviser API
   description: (laa-legal-adviser-api)
-  position: '3300,1400'
+  position: '3300,1300'
 - type: Software System
   name: Provider Case Handler
   tags: external
@@ -68,6 +68,11 @@ elements:
   name: Provider Identity Database
   tags: database
   position: '2300,2000'
+- type: Software System
+  name: postcodes.io
+  description: Postcode lookup API for latitude/longitude conversion
+  tags: external
+  position: '3600,2000'
 
 relationships:
 - source: Case Handler
@@ -121,6 +126,9 @@ relationships:
 - source: Hub Job
   description: Periodically updates Civil Legal Provider details
   destination: Provider Identity Database
+- source: Legal Adviser API
+  description: uses
+  destination: postcodes.io
 - source: Management Information Analyst
   description: Periodically downloads Civil Legal Provider details
   destination: Data Warehouse

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -8,7 +8,7 @@ description: Describes the components related to accessing civil legal aid for m
 
 elements:
 - type: Person
-  name: Case Handler
+  name: Operator
   position: '2025,350'
 - type: Person
   name: Citizen
@@ -28,7 +28,7 @@ elements:
   name: Management Information Team
   position: '3025,1950'
 - type: Software System
-  name: Case Handler Identity Database
+  name: Operator Identity Database
   tags: database
   position: '1700,2000'
 - type: Software System
@@ -81,13 +81,13 @@ elements:
   position: '3600,2000'
 
 relationships:
-- source: Case Handler
+- source: Operator
   description: Talks to
   destination: Citizen
-- source: Case Handler
+- source: Operator
   description: Checks eligibility and data of incoming legal aid requests
   destination: Civil Legal Advice Case Handling System
-- source: Case Handler
+- source: Operator
   description: Talks to
   destination: Civil Legal Advice Specialist Provider
 - source: Check Legal Aid
@@ -107,7 +107,7 @@ relationships:
   destination: Find a Legal Adviser
 - source: Civil Legal Advice Backend
   description: uses
-  destination: Case Handler Identity Database
+  destination: Operator Identity Database
 - source: Civil Legal Advice Backend
   description: uses
   destination: Provider Identity Database

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -35,7 +35,7 @@ elements:
   description: (CLA_backend)
   position: '1900,1300'
 - type: Software System
-  name: Civil Legal Advice Case Handler
+  name: Civil Legal Advice Case Handling System
   description: (CLA_frontend)
   tags: web
   position: '1000,700'
@@ -75,7 +75,7 @@ relationships:
   destination: Citizen
 - source: Case Handler
   description: Checks eligibility and data of incoming legal aid requests
-  destination: Civil Legal Advice Case Handler
+  destination: Civil Legal Advice Case Handling System
 - source: Case Handler
   description: Talks to
   destination: Civil Legal Provider
@@ -100,12 +100,12 @@ relationships:
 - source: Civil Legal Advice Backend
   description: uses
   destination: Provider Identity Database
-- source: Civil Legal Advice Case Handler
+- source: Civil Legal Advice Case Handling System
   description: Registers and updates incoming legal aid requests
   destination: Civil Legal Advice Backend
 - source: Civil Legal Provider
   description: Logs in and uploads work report CSV to
-  destination: Civil Legal Advice Case Handler
+  destination: Civil Legal Advice Case Handling System
 - source: Civil Legal Provider
   description: Manages work via
   destination: Provider Case Handler

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -19,7 +19,7 @@ elements:
   tags: external
   position: '1025,50'
 - type: Person
-  name: Management Information Analyst
+  name: Management Information Team
   position: '3025,1950'
 - type: Software System
   name: Case Handler Identity Database
@@ -129,10 +129,10 @@ relationships:
 - source: Legal Adviser API
   description: uses
   destination: postcodes.io
-- source: Management Information Analyst
+- source: Management Information Team
   description: Periodically downloads Civil Legal Provider details
   destination: Data Warehouse
-- source: Management Information Analyst
+- source: Management Information Team
   description: Periodically updates Civil Legal Provider details
   destination: Legal Adviser API
 

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -9,31 +9,31 @@ description: Describes the components related to accessing civil legal aid for m
 elements:
 - type: Person
   name: Case Handler
-  position: '1925,350'
+  position: '2025,350'
 - type: Person
   name: Citizen
   tags: external
-  position: '2825,50'
+  position: '3325,50'
 - type: Person
   name: Civil Legal Provider
   tags: external
   position: '1025,50'
 - type: Person
   name: Management Information Analyst
-  position: '2825,1950'
+  position: '3325,1950'
 - type: Software System
   name: Case Handler Identity Database
   tags: database
-  position: '1000,1100'
+  position: '1700,2000'
 - type: Software System
   name: Check Legal Aid
   description: (CLA_public) https://checklegalaid.service.gov.uk/
   tags: web,public
-  position: '2500,700'
+  position: '2900,700'
 - type: Software System
   name: Civil Legal Advice Backend
   description: (CLA_backend)
-  position: '1900,1300'
+  position: '2000,1400'
 - type: Software System
   name: Civil Legal Advice Case Handling System
   description: (CLA_frontend) https://cases.civillegaladvice.service.gov.uk/
@@ -42,24 +42,24 @@ elements:
 - type: Software System
   name: Contract Work Assessment
   description: (CWA) Source of truth for Civil Legal Provider details (amongst other responsibilities)
-  position: '100,2000'
+  position: '1000,2800'
 - type: Software System
   name: Data Warehouse
   description: (OBIEE) Collects data related to common concepts from various sources
   tags: database
-  position: '1900,2000'
+  position: '3300,2800'
 - type: Software System
   name: Find a Legal Adviser
   description: (FALA) https://find-legal-advice.justice.gov.uk/
   tags: web,public
-  position: '3000,700'
+  position: '3700,700'
 - type: Software System
   name: Hub Job
-  position: '1000,2000'
+  position: '2000,2800'
 - type: Software System
   name: Legal Adviser API
   description: (laa-legal-adviser-api)
-  position: '2800,1300'
+  position: '3300,1400'
 - type: Software System
   name: Provider Case Handler
   tags: external
@@ -67,7 +67,7 @@ elements:
 - type: Software System
   name: Provider Identity Database
   tags: database
-  position: '1000,1500'
+  position: '2300,2000'
 
 relationships:
 - source: Case Handler
@@ -151,4 +151,4 @@ styles:
   tag: web
   shape: WebBrowser
 
-size: A4_Landscape
+size: A3_Landscape

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -20,25 +20,25 @@ elements:
   position: '1125,50'
 - type: Person
   name: Management Information Analyst
-  position: '1925,1950'
+  position: '2825,1950'
 - type: Software System
   name: Case Handler Identity Database
   tags: database
-  position: '1100,1700'
+  position: '1100,1600'
 - type: Software System
   name: Check Legal Aid
   description: (CLA_public) https://checklegalaid.service.gov.uk/
   tags: web,public
-  position: '2500,900'
+  position: '2500,700'
 - type: Software System
   name: Civil Legal Advice Backend
   description: (CLA_backend)
-  position: '1900,1500'
+  position: '1900,1400'
 - type: Software System
   name: Civil Legal Advice Case Handler
   description: (CLA_frontend)
   tags: web
-  position: '1100,900'
+  position: '1100,700'
 - type: Software System
   name: Contract Work Assessment
   description: (CWA) Source of truth for Civil Legal Provider details (amongst other responsibilities)
@@ -47,16 +47,16 @@ elements:
   name: Data Warehouse
   description: (OBIEE) Collects data related to common concepts from various sources
   tags: database
-  position: '1100,2000'
+  position: '1900,2000'
 - type: Software System
   name: Find a Legal Adviser
   description: (FALA) https://find-legal-advice.justice.gov.uk/
   tags: web,public
-  position: '3000,900'
+  position: '3000,700'
 - type: Software System
   name: Legal Adviser API
   description: (laa-legal-adviser-api)
-  position: '2800,2000'
+  position: '2800,1400'
 - type: Software System
   name: Provider Case Handler
   tags: external
@@ -64,7 +64,7 @@ elements:
 - type: Software System
   name: Provider Identity Database
   tags: database
-  position: '1100,1400'
+  position: '1100,1200'
 
 relationships:
 - source: Case Handler

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -8,88 +8,79 @@ description: Describes the components related to accessing civil legal aid for m
 
 elements:
 - type: Person
-  name: Operator
-  position: '2025,350'
-- type: Person
   name: Citizen
   tags: external
-  position: '3325,50'
+  position: '3725,350'
 - type: Person
   name: Civil Legal Advice Specialist Provider
   tags: external
-  position: '1025,50'
+  position: '1525,350'
 - type: Person
   name: Contract Analyst
-  position: '125,650'
+  position: '725,750'
 - type: Person
   name: First Line Support
-  position: '125,1250'
+  position: '725,1250'
 - type: Person
   name: Management Information Team
-  position: '3025,1950'
-- type: Software System
-  name: Operator Identity Database
-  tags: database
-  position: '1700,2000'
+  position: '3225,2250'
+- type: Person
+  name: Operator
+  position: '2625,50'
 - type: Software System
   name: Check Legal Aid
   description: (CLA_public) https://checklegalaid.service.gov.uk/
   tags: web,public
-  position: '3000,700'
+  position: '2600,1100'
 - type: Software System
   name: Civil Legal Advice Backend
   description: (CLA_backend)
-  position: '2000,1300'
+  position: '2100,1600'
 - type: Software System
   name: Civil Legal Advice Case Handling System
   description: (CLA_frontend) https://cases.civillegaladvice.service.gov.uk/
   tags: web,public
-  position: '1000,700'
+  position: '1500,1100'
 - type: Software System
   name: Contract Work Assessment
   description: (CWA) Source of truth for Civil Legal Advice Specialist Provider details (amongst other responsibilities)
-  position: '1000,2800'
+  position: '1000,3000'
 - type: Software System
   name: Data Warehouse
   description: (OBIEE) Collects data related to common concepts from various sources
   tags: database
-  position: '3000,2800'
+  position: '3200,3000'
 - type: Software System
   name: Find a Legal Adviser
   description: (FALA) https://find-legal-advice.justice.gov.uk/
   tags: web,public
-  position: '3600,700'
+  position: '3700,1100'
 - type: Software System
   name: Hub Job
-  position: '2300,2800'
+  position: '2100,3000'
 - type: Software System
   name: Legal Adviser Location Search API
   description: (laa-legal-adviser-api)
-  position: '3300,1300'
+  position: '3200,1600'
 - type: Software System
-  name: Provider's Case Handling System
-  tags: external
-  position: '100,100'
+  name: Operator Identity Database
+  tags: database
+  position: '1600,2300'
 - type: Software System
   name: Provider Identity Database
   tags: database
-  position: '2300,2000'
+  position: '2100,2300'
+- type: Software System
+  name: Provider's Case Handling System
+  tags: external
+  position: '700,400'
 - type: Software System
   name: postcodes.io
   description: Postcode lookup API for latitude/longitude conversion
   tags: external
-  position: '3600,2000'
+  position: '3700,2300'
 
 relationships:
-- source: Operator
-  description: Talks to
-  destination: Citizen
-- source: Operator
-  description: Checks eligibility and data of incoming legal aid requests
-  destination: Civil Legal Advice Case Handling System
-- source: Operator
-  description: Talks to
-  destination: Civil Legal Advice Specialist Provider
 - source: Check Legal Aid
   description: Registers incoming legal aid requests
   destination: Civil Legal Advice Backend
@@ -117,6 +108,11 @@ relationships:
 - source: Civil Legal Advice Specialist Provider
   description: Logs in and uploads work report CSV to
   destination: Civil Legal Advice Case Handling System
+- source: Civil Legal Advice Specialist Provider
+  description: Looking for nearby legal advisers for citizens
+  destination: Find a Legal Adviser
+  vertices:
+  - '3500,700'
 - source: Civil Legal Advice Specialist Provider
   description: Manages work via
   destination: Provider's Case Handling System
@@ -147,6 +143,15 @@ relationships:
 - source: Management Information Team
   description: Periodically updates Civil Legal Advice Specialist Provider details
   destination: Legal Adviser Location Search API
+- source: Operator
+  description: Talks to
+  destination: Citizen
+- source: Operator
+  description: Checks eligibility and data of incoming legal aid requests
+  destination: Civil Legal Advice Case Handling System
+- source: Operator
+  description: Talks to
+  destination: Civil Legal Advice Specialist Provider
 
 styles:
 - type: element

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -26,8 +26,8 @@ elements:
   tags: database
   position: '100,800'
 - type: Software System
-  name: Civil Legal Advice
-  description: (CLA_public)
+  name: Check Legal Aid
+  description: (CLA_public) https://checklegalaid.service.gov.uk/
   tags: web
   position: '2700,1000'
 - type: Software System
@@ -72,9 +72,15 @@ relationships:
 - source: Case Handler
   description: Talks to
   destination: Civil Legal Provider
+- source: Check Legal Aid
+  description: Registers incoming legal aid requests
+  destination: Civil Legal Advice Case Handler
+- source: Check Legal Aid
+  description: uses
+  destination: Legal Adviser API
 - source: Citizen
   description: Looking for legal aid
-  destination: Civil Legal Advice
+  destination: Check Legal Aid
 - source: Citizen
   description: Talks to
   destination: Civil Legal Provider
@@ -87,12 +93,6 @@ relationships:
 - source: Civil Legal Advice Case Handler
   description: uses
   destination: Provider Identity Database
-- source: Civil Legal Advice
-  description: Registers incoming legal aid requests
-  destination: Civil Legal Advice Case Handler
-- source: Civil Legal Advice
-  description: uses
-  destination: Legal Adviser API
 - source: Civil Legal Provider
   description: Logs in and uploads work report CSV to
   destination: Civil Legal Advice Case Handler

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -13,7 +13,7 @@ elements:
 - type: Person
   name: Citizen
   tags: external
-  position: '2725,50'
+  position: '2825,50'
 - type: Person
   name: Civil Legal Provider
   tags: external
@@ -48,11 +48,11 @@ elements:
   name: Find a Legal Adviser
   description: (FALA)
   tags: web
-  position: '2700,1500'
+  position: '3000,1000'
 - type: Software System
   name: Legal Adviser API
   description: (laa-legal-adviser-api)
-  position: '2700,2000'
+  position: '2800,2000'
 - type: Software System
   name: Provider Case Handler
   tags: external
@@ -78,6 +78,9 @@ relationships:
 - source: Citizen
   description: Talks to
   destination: Civil Legal Provider
+- source: Citizen
+  description: Looking for nearby legal advisers
+  destination: Find a Legal Adviser
 - source: Civil Legal Advice Case Handler
   description: uses
   destination: Case Handler Identity Database
@@ -88,8 +91,8 @@ relationships:
   description: Registers incoming legal aid requests
   destination: Civil Legal Advice Case Handler
 - source: Civil Legal Advice
-  description: Get Civil Legal Provider details if necessary
-  destination: Find a Legal Adviser
+  description: uses
+  destination: Legal Adviser API
 - source: Civil Legal Provider
   description: Logs in and uploads work report CSV to
   destination: Civil Legal Advice Case Handler

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -17,14 +17,14 @@ elements:
 - type: Person
   name: Civil Legal Provider
   tags: external
-  position: '1125,50'
+  position: '1025,50'
 - type: Person
   name: Management Information Analyst
   position: '2825,1950'
 - type: Software System
   name: Case Handler Identity Database
   tags: database
-  position: '1100,1600'
+  position: '1000,1100'
 - type: Software System
   name: Check Legal Aid
   description: (CLA_public) https://checklegalaid.service.gov.uk/
@@ -33,12 +33,12 @@ elements:
 - type: Software System
   name: Civil Legal Advice Backend
   description: (CLA_backend)
-  position: '1900,1400'
+  position: '1900,1300'
 - type: Software System
   name: Civil Legal Advice Case Handler
   description: (CLA_frontend)
   tags: web
-  position: '1100,700'
+  position: '1000,700'
 - type: Software System
   name: Contract Work Assessment
   description: (CWA) Source of truth for Civil Legal Provider details (amongst other responsibilities)
@@ -54,9 +54,12 @@ elements:
   tags: web,public
   position: '3000,700'
 - type: Software System
+  name: Hub Job
+  position: '1000,2000'
+- type: Software System
   name: Legal Adviser API
   description: (laa-legal-adviser-api)
-  position: '2800,1400'
+  position: '2800,1300'
 - type: Software System
   name: Provider Case Handler
   tags: external
@@ -64,7 +67,7 @@ elements:
 - type: Software System
   name: Provider Identity Database
   tags: database
-  position: '1100,1200'
+  position: '1000,1500'
 
 relationships:
 - source: Case Handler
@@ -108,13 +111,16 @@ relationships:
   destination: Provider Case Handler
 - source: Contract Work Assessment
   description: Periodically updates Civil Legal Provider details
-  destination: Data Warehouse
-- source: Data Warehouse
-  description: Periodically updates Civil Legal Provider details
-  destination: Civil Legal Advice Backend
+  destination: Hub Job
 - source: Find a Legal Adviser
   description: uses
   destination: Legal Adviser API
+- source: Hub Job
+  description: Periodically updates Civil Legal Provider details
+  destination: Data Warehouse
+- source: Hub Job
+  description: Periodically updates Civil Legal Provider details
+  destination: Provider Identity Database
 - source: Management Information Analyst
   description: Periodically downloads Civil Legal Provider details
   destination: Data Warehouse

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -19,8 +19,8 @@ elements:
   tags: external
   position: '1100,80'
 - type: Person
-  name: Manager Information Analyst
-  position: '1900,1920'
+  name: Management Information Analyst
+  position: '1900,1960'
 - type: Software System
   name: Case Handler Identity Database
   tags: database
@@ -105,10 +105,10 @@ relationships:
 - source: Find a Legal Adviser
   description: uses
   destination: Legal Adviser API
-- source: Manager Information Analyst
+- source: Management Information Analyst
   description: Periodically downloads Civil Legal Provider details
   destination: Data Warehouse
-- source: Manager Information Analyst
+- source: Management Information Analyst
   description: Periodically updates Civil Legal Provider details
   destination: Legal Adviser API
 

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -9,7 +9,7 @@ description: Describes the components related to accessing civil legal aid for m
 elements:
 - type: Person
   name: Case Handler
-  position: '1925,450'
+  position: '1925,350'
 - type: Person
   name: Citizen
   tags: external
@@ -24,17 +24,21 @@ elements:
 - type: Software System
   name: Case Handler Identity Database
   tags: database
-  position: '100,800'
+  position: '1100,1700'
 - type: Software System
   name: Check Legal Aid
   description: (CLA_public) https://checklegalaid.service.gov.uk/
   tags: web
-  position: '2700,1000'
+  position: '2500,900'
+- type: Software System
+  name: Civil Legal Advice Backend
+  description: (CLA_backend)
+  position: '1900,1500'
 - type: Software System
   name: Civil Legal Advice Case Handler
-  description: (CLA_frontend and CLA_backend)
+  description: (CLA_frontend)
   tags: web
-  position: '1100,1000'
+  position: '1100,900'
 - type: Software System
   name: Contract Work Assessment
   description: (CWA) Source of truth for Civil Legal Provider details (amongst other responsibilities)
@@ -48,7 +52,7 @@ elements:
   name: Find a Legal Adviser
   description: (FALA)
   tags: web
-  position: '3000,1000'
+  position: '3000,900'
 - type: Software System
   name: Legal Adviser API
   description: (laa-legal-adviser-api)
@@ -60,7 +64,7 @@ elements:
 - type: Software System
   name: Provider Identity Database
   tags: database
-  position: '100,1400'
+  position: '1100,1400'
 
 relationships:
 - source: Case Handler
@@ -74,7 +78,7 @@ relationships:
   destination: Civil Legal Provider
 - source: Check Legal Aid
   description: Registers incoming legal aid requests
-  destination: Civil Legal Advice Case Handler
+  destination: Civil Legal Advice Backend
 - source: Check Legal Aid
   description: uses
   destination: Legal Adviser API
@@ -87,12 +91,15 @@ relationships:
 - source: Citizen
   description: Looking for nearby legal advisers
   destination: Find a Legal Adviser
-- source: Civil Legal Advice Case Handler
+- source: Civil Legal Advice Backend
   description: uses
   destination: Case Handler Identity Database
-- source: Civil Legal Advice Case Handler
+- source: Civil Legal Advice Backend
   description: uses
   destination: Provider Identity Database
+- source: Civil Legal Advice Case Handler
+  description: Registers and updates incoming legal aid requests
+  destination: Civil Legal Advice Backend
 - source: Civil Legal Provider
   description: Logs in and uploads work report CSV to
   destination: Civil Legal Advice Case Handler
@@ -104,7 +111,7 @@ relationships:
   destination: Data Warehouse
 - source: Data Warehouse
   description: Periodically updates Civil Legal Provider details
-  destination: Civil Legal Advice Case Handler
+  destination: Civil Legal Advice Backend
 - source: Find a Legal Adviser
   description: uses
   destination: Legal Adviser API

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -28,7 +28,7 @@ elements:
   name: Operator
   position: '2625,50'
 - type: Software System
-  name: Check Legal Aid
+  name: Check If You Can Get Legal Aid
   description: (CLA_public) https://checklegalaid.service.gov.uk/
   tags: web,public
   position: '2600,1100'
@@ -81,15 +81,15 @@ elements:
   position: '3700,2300'
 
 relationships:
-- source: Check Legal Aid
+- source: Check If You Can Get Legal Aid
   description: Registers incoming legal aid requests
   destination: Civil Legal Advice Backend
-- source: Check Legal Aid
+- source: Check If You Can Get Legal Aid
   description: uses
   destination: Legal Adviser Location Search API
 - source: Citizen
   description: Looking for legal aid
-  destination: Check Legal Aid
+  destination: Check If You Can Get Legal Aid
 - source: Citizen
   description: Talks to
   destination: Civil Legal Advice Specialist Provider

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -19,6 +19,12 @@ elements:
   tags: external
   position: '1025,50'
 - type: Person
+  name: Contract Analyst
+  position: '125,650'
+- type: Person
+  name: First Line Support
+  position: '125,1250'
+- type: Person
   name: Management Information Team
   position: '3025,1950'
 - type: Software System
@@ -114,12 +120,18 @@ relationships:
 - source: Civil Legal Advice Specialist Provider
   description: Manages work via
   destination: Provider Case Handler
+- source: Contract Analyst
+  description: Periodically downloads reports
+  destination: Civil Legal Advice Case Handling System
 - source: Contract Work Assessment
   description: Periodically updates Civil Legal Advice Specialist Provider details
   destination: Hub Job
 - source: Find a Legal Adviser
   description: uses
   destination: Legal Adviser Location Search API
+- source: First Line Support
+  description: Manages provider and operator accounts
+  destination: Civil Legal Advice Case Handling System
 - source: Hub Job
   description: Periodically updates Civil Legal Advice Specialist Provider details
   destination: Data Warehouse


### PR DESCRIPTION
## What does this pull request do?

The biggest changes are:

1. The public facing web applications (`cla_frontend`, `cla_public`, `fala`) are re-coloured (`#b2b3cf`) to make that visible.
1. The civil legal advice case handling system and backend have been separated.
1. Hub jobs have been added to the diagram to represent _how_ data is synchronised between systems.
1. postcodes.io is mentioned as an external dependency for [laalaa][laalaa].

## Where should the reviewer start?

Commit-by-commit, please.

It's recommended to use the "rich image diff" tool in GitHub:

<img width="995" alt="screen shot 2018-08-23 at 17 18 40" src="https://user-images.githubusercontent.com/1526295/44582289-032e4900-a799-11e8-8d4e-865092b21717.png">

[laalaa]: https://github.com/ministryofjustice/laa-legal-adviser-api/