### PR TITLE
Add SendGrid to the civil legal aid diagram

### DIFF
--- a/diagrams/get-access/civil-legal-aid-system-landscape.png
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:922c6d6027ce1033fd2ed0a1a918ca14af1eda2ff4e6b11a92292ee9ea80a0f0
-size 1059408
+oid sha256:4fb2d34c8d237dad9d3e54dac306a39efd341ddf0d6c92e5d4e81cdd6b411cb1
+size 1087798

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -34,7 +34,7 @@ elements:
   position: '2600,1100'
 - type: Software System
   name: Civil Legal Advice Backend
-  description: (CLA_backend)
+  description: (CLA_backend) https://fox.civillegaladvice.service.gov.uk/admin
   position: '2100,1600'
 - type: Software System
   name: Civil Legal Advice Case Handling System

--- a/diagrams/get-access/civil-legal-aid-system-landscape.yaml
+++ b/diagrams/get-access/civil-legal-aid-system-landscape.yaml
@@ -75,6 +75,11 @@ elements:
   tags: external
   position: '700,400'
 - type: Software System
+  name: SendGrid
+  description: 3rd party system to send e-mails
+  tags: external
+  position: '2600,2300'
+- type: Software System
   name: postcodes.io
   description: Postcode lookup API for latitude/longitude conversion
   tags: external
@@ -87,6 +92,9 @@ relationships:
 - source: Check If You Can Get Legal Aid
   description: uses
   destination: Legal Adviser Location Search API
+- source: Check If You Can Get Legal Aid
+  description: Sends confirmation e-mails via
+  destination: SendGrid
 - source: Citizen
   description: Looking for legal aid
   destination: Check If You Can Get Legal Aid


### PR DESCRIPTION
## What does this pull request do?

- Adds SendGrid to the civil legal aid diagram so that we are aware that we use a 3rd party provider for e-mails.
- **Bonus** Adds the public URL to the civil legal aid backend system.

🙋‍♂️ For review, I would recommend using the "Swipe" image diff: https://github.com/ministryofjustice/laa-architecture-documentation/pull/10/files?short_path=3021a9d#diff-3021a9d2ee611803bbff6653fec5aad5