### PR TITLE
Add civil legal aid system container diagram

### DIFF
--- a/diagrams/get-access/civil-legal-aid-containers.png
+++ b/diagrams/get-access/civil-legal-aid-containers.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9607c2762b85f32ae034111bde6cf6de9e95283da87394bc1e2f6f5e8ad675af
-size 774701
+oid sha256:5fb4c3004ced4f033a643ecf9350cc4e3528a5f6f0f926cc6ff7a9b7294ba158
+size 865453

--- a/diagrams/get-access/civil-legal-aid-containers.png
+++ b/diagrams/get-access/civil-legal-aid-containers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9607c2762b85f32ae034111bde6cf6de9e95283da87394bc1e2f6f5e8ad675af
+size 774701

--- a/diagrams/get-access/civil-legal-aid-containers.png
+++ b/diagrams/get-access/civil-legal-aid-containers.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5fb4c3004ced4f033a643ecf9350cc4e3528a5f6f0f926cc6ff7a9b7294ba158
-size 865453
+oid sha256:8319b62f3605d86b4ec6018b3cd402f57dee021b4a33543c7f5d4233e4cbd07f
+size 941875

--- a/diagrams/get-access/civil-legal-aid-containers.yaml
+++ b/diagrams/get-access/civil-legal-aid-containers.yaml
@@ -54,6 +54,11 @@ elements:
 - type: Software System
   name: Find a Legal Adviser
   tags: web
+  position: '4300,400'
+- type: Software System
+  name: Ordnance Survey Places API
+  description: 3rd party address finder API
+  tags: external
   position: '4300,1000'
 - type: Software System
   name: Provider's Case Handling System
@@ -115,6 +120,9 @@ relationships:
 - source: cla_public
   description: Provides "which provider is nearest to my home" via
   destination: Find a Legal Adviser
+- source: cla_public
+  description: Looks up addresses for during the contact form
+  destination: Ordnance Survey Places API
 - source: cla_public
   description: Sends confirmation and notification e-mails to citizens via
   destination: SendGrid

--- a/diagrams/get-access/civil-legal-aid-containers.yaml
+++ b/diagrams/get-access/civil-legal-aid-containers.yaml
@@ -1,0 +1,152 @@
+links:
+  The FC4 Framework: https://fundingcircle.github.io/fc4-framework/
+  Structurizr Express: https://structurizr.com/express
+---
+type: Container
+scope: Civil Legal Aid
+description: Describes the containers related to accessing civil legal aid
+
+elements:
+- type: Person
+  name: Citizen
+  description: Member of the public in England and Wales
+  tags: external
+  position: '3425,250'
+- type: Person
+  name: Civil Legal Advice Specialist Provider
+  tags: external
+  position: '525,950'
+- type: Person
+  name: Management Information Team
+  position: '1225,1550'
+- type: Person
+  name: Operator
+  description: Contact centre personnel who signposts members of the public in their legal help queries
+  position: '1225,250'
+- type: Software System
+  name: Civil Legal Aid
+  containers:
+  - type: Container
+    name: cla_backend
+    description: '[fox.civillegaladvice.service.gov.uk] Case Handling System Administration'
+    tags: web,focus
+    position: '2800,1600'
+  - type: Container
+    name: cla_frontend
+    description: '[cases.civillegaladvice.service.gov.uk] Case Handling System'
+    tags: web,focus
+    position: '2200,1000'
+  - type: Container
+    name: cla_public
+    description: '[checklegalaid.service.gov.uk] Public-facing website that allows people to self-assess for signposting or schedule callbacks'
+    tags: web,focus
+    position: '3400,1000'
+  - type: Container
+    name: Civil Legal Aid database
+    description: '[PostgreSQL] Source of truth for civil legal aid cases, callbacks, logins and specialist provider submissions'
+    tags: database,focus
+    position: '2200,2200'
+  - type: Container
+    name: Civil Legal Aid replica database
+    description: '[PostgreSQL] Replica database used for generating reports'
+    tags: database,focus
+    position: '3400,2200'
+- type: Software System
+  name: Find a Legal Adviser
+  tags: web
+  position: '4300,1000'
+- type: Software System
+  name: Provider's Case Handling System
+  tags: external
+  position: '500,400'
+- type: Software System
+  name: SendGrid
+  description: 3rd party system to send e-mails
+  tags: external
+  position: '4300,1600'
+
+relationships:
+- source: Citizen
+  description: Talks to
+  destination: Civil Legal Advice Specialist Provider
+- source: Citizen
+  description: Looking for legal aid
+  destination: cla_public
+- source: Civil Legal Advice Specialist Provider
+  description: Manages work via
+  destination: Provider's Case Handling System
+- source: Civil Legal Advice Specialist Provider
+  description: Logs in and uploads work report CSV to
+  destination: cla_frontend
+- source: Civil Legal Aid database
+  description: Replicates to
+  destination: Civil Legal Aid replica database
+- source: Management Information Team
+  description: Periodically downloads case detail reports
+  destination: cla_backend
+- source: Operator
+  description: Talks to
+  destination: Citizen
+- source: Operator
+  description: Talks to
+  destination: Civil Legal Advice Specialist Provider
+- source: Operator
+  description: Checks eligibility and data of incoming legal aid requests
+  destination: cla_frontend
+- source: cla_backend
+  description: Real-time updates and details via
+  destination: Civil Legal Aid database
+- source: cla_backend
+  description: Generates reports from
+  destination: Civil Legal Aid replica database
+- source: cla_backend
+  description: Sends confirmation and notification e-mails to citizens and providers via
+  destination: SendGrid
+- source: cla_frontend
+  description: Stores created and edited case, callback and submission details via
+  destination: cla_backend
+  vertices:
+  - '2550,1400'
+- source: cla_frontend
+  description: Provides operator and provider login functionality via
+  destination: cla_backend
+  vertices:
+  - '2850,1250'
+- source: cla_public
+  description: Provides "which provider is nearest to my home" via
+  destination: Find a Legal Adviser
+- source: cla_public
+  description: Sends confirmation and notification e-mails to citizens via
+  destination: SendGrid
+- source: cla_public
+  description: Stores entered case and callback details via
+  destination: cla_backend
+
+styles:
+- type: element
+  tag: Element
+  background: '#c9cadb'
+  color: '#25263c'
+- type: element
+  tag: Person
+  shape: Person
+- type: element
+  tag: database
+  shape: Cylinder
+- type: element
+  tag: external
+  background: '#c7e7e4'
+  color: '#0e3532'
+- type: element
+  tag: focus
+  background: '#5a5c92'
+  color: '#ffffff'
+- type: element
+  tag: focus,external
+  background: '#28a197'
+  color: '#ffffff'
+- type: element
+  tag: web
+  shape: WebBrowser
+
+size: A3_Landscape

--- a/diagrams/get-access/civil-legal-aid-containers.yaml
+++ b/diagrams/get-access/civil-legal-aid-containers.yaml
@@ -17,7 +17,7 @@ elements:
   tags: external
   position: '525,950'
 - type: Person
-  name: Management Information Team
+  name: Direct Services Team
   position: '1225,1550'
 - type: Person
   name: Operator
@@ -26,6 +26,16 @@ elements:
 - type: Software System
   name: Civil Legal Aid
   containers:
+  - type: Container
+    name: Civil Legal Aid database
+    description: '[PostgreSQL] Source of truth for civil legal aid cases, callbacks, logins and specialist provider submissions'
+    tags: database,focus
+    position: '2200,2200'
+  - type: Container
+    name: Civil Legal Aid replica database
+    description: '[PostgreSQL] Replica database used for generating reports'
+    tags: database,focus
+    position: '3400,2200'
   - type: Container
     name: cla_backend
     description: '[fox.civillegaladvice.service.gov.uk] Case Handling System Administration'
@@ -41,16 +51,6 @@ elements:
     description: '[checklegalaid.service.gov.uk] Public-facing website that allows people to self-assess for signposting or schedule callbacks'
     tags: web,focus
     position: '3400,1000'
-  - type: Container
-    name: Civil Legal Aid database
-    description: '[PostgreSQL] Source of truth for civil legal aid cases, callbacks, logins and specialist provider submissions'
-    tags: database,focus
-    position: '2200,2200'
-  - type: Container
-    name: Civil Legal Aid replica database
-    description: '[PostgreSQL] Replica database used for generating reports'
-    tags: database,focus
-    position: '3400,2200'
 - type: Software System
   name: Find a Legal Adviser
   tags: web
@@ -86,9 +86,19 @@ relationships:
 - source: Civil Legal Aid database
   description: Replicates to
   destination: Civil Legal Aid replica database
-- source: Management Information Team
-  description: Periodically downloads case detail reports
+- source: Direct Services Team
+  description: Runs reports to manage the specialist provider and operator service contracts
   destination: cla_backend
+  vertices:
+  - '2200,1600'
+- source: Direct Services Team
+  description: Periodically downloads case extract reports to propagate to management information systems
+  destination: cla_backend
+  vertices:
+  - '2200,1950'
+- source: Direct Services Team
+  description: Views cases to manage the specialist provider and operator service contracts
+  destination: cla_frontend
 - source: Operator
   description: Talks to
   destination: Citizen


### PR DESCRIPTION
## What does this pull request do?

Provides a new diagram with a detailed zoom-in into what containers build up the Civil Legal Aid system.

## Why make these changes?

The diagram update in #11 provides a high-level system view of civil legal aid; this diagram provides a more in-depth look of how containers within that system interact with each other.

## Show me the image

![civil-legal-aid-containers](https://media.githubusercontent.com/media/ministryofjustice/laa-architecture-documentation/aae5f711d46f673bae27b78fbadcda74f3c98ce4/diagrams/get-access/civil-legal-aid-containers.png)
