### PR TITLE
Document the intended audience for each Get Access diagram

### DIFF
--- a/diagrams/get-access/README.md
+++ b/diagrams/get-access/README.md
@@ -1,0 +1,31 @@
+# Get Access service area
+
+## High-level diagrams
+
+**Intended audience**: Everyone (technical and non-technical).
+
+These diagrams aim to inform about the _users_ and _integrations_ around the system in focus. The drawings are intended
+to support these questions:
+
+- Who uses the system (humans, internal or external)
+- What is the use-case for the system, what problem does it solve
+- What integrations exist with other systems
+
+| Diagram | Description |
+| --- | --- |
+| <img src="civil-legal-aid-system-landscape.png" width="280"/> | Shows the Civil Legal Aid and Find a Legal Adviser systems. |
+
+## Container diagrams
+
+**Intended audience**: Service teams involved in developing the systems.
+
+These diagrams support these questions:
+
+- What are the moving parts of the system?
+- Which part do users or other systems use?
+- How does it all work together?
+
+| Diagram | Description |
+| --- | --- |
+| <img src="civil-legal-aid-containers.png" width="280"/> | Container diagram for the Civil Legal Aid system. |
+| <img src="find-a-legal-adviser-containers.png" width="280"/> | Container diagram for the Find a Legal Adviser system. |


### PR DESCRIPTION
## What does this pull request do?

Creates a readme in `diagrams/get-access/` folder to document the intended audience of each diagram.
 
## Why make these changes?

Based on a talk I heard over the weekend which suggested to identify the intended audience of documentation.

## Show me the image

There is no image; the readme can be viewed at https://github.com/ministryofjustice/laa-architecture-documentation/pull/17/files?short_path=17a7fcc