### PR TITLE
Add CircleCI architecture decision record

### DIFF
--- a/decisions/001-using-circleci.md
+++ b/decisions/001-using-circleci.md
@@ -20,7 +20,7 @@ Facts in favour of CircleCI:
 Given the above context, we feel that defaulting to CircleCI is a sensible decision as it has the following benefits:
 
 * Contributing to applications across LAA Digital will not require learning another CI tool.
-* Support from many teams over `#circleci-users` Slack channel.
+* Support from many teams over [`#circleci-users`][circleci-users-slack] Slack channel.
 * Sharing similar code, for example, tagging and pushing Docker images to Elastic Container Registry (ECR) and deploying
   to Cloud Platform's Kubernetes platform.
 
@@ -41,3 +41,5 @@ The **default** choice of continuous integration service in the LAA Digital team
 New jobs and significant changes should migrate to CircleCI.
 
 **New** LAA applications should start with CircleCI as a default choice unless there is a compelling reason otherwise.
+
+[circleci-users-slack]: https://mojdt.slack.com/messages/CCSD5F397

--- a/decisions/001-using-circleci.md
+++ b/decisions/001-using-circleci.md
@@ -1,0 +1,43 @@
+# ADR-001: Using CircleCI as a continuous integration service
+
+## Status
+
+Proposed
+
+## Context
+
+There are a couple of continuous integration (CI) services used by the Ministry of Justice (MoJ) Digital teams and the
+Legal Aid Agency (LAA) Digital teams. The list includes Travis, Semaphore, Concourse, Circle, Jenkins.
+
+Facts in favour of CircleCI:
+
+* Many teams started using CircleCI to integrate with the new Cloud Platform service using workflows
+  to implement approvals and deployment.
+* CircleCI has grown in features and their support for custom job Docker images and "orbs" as
+  reusable commands work well for the majority of our use cases.
+* To support private projects, MoJ Digital has invested in private executors on CircleCI.
+
+Given the above context, we feel that defaulting to CircleCI is a sensible decision as it has the following benefits:
+
+* Contributing to applications across LAA Digital will not require learning another CI tool.
+* Support from many teams over `#circleci-users` Slack channel.
+* Sharing similar code, for example, tagging and pushing Docker images to Elastic Container Registry (ECR) and deploying
+  to Cloud Platform's Kubernetes platform.
+
+The downsides are:
+
+* A bit of a learning curve compared to inference-based CI tools.
+* We might step on each others' toes if we expand our CircleCI usage, resulting in queues on builds and deployments.
+  Needs to be monitored.
+
+## Decision
+
+The **default** choice of continuous integration service in the LAA Digital teams is
+**[CircleCI](https://circleci.com)**.
+
+## Consequences
+
+**Existing** LAA repositories using other CI services may continue using them until a change is necessary.
+New jobs and significant changes should migrate to CircleCI.
+
+**New** LAA applications should start with CircleCI as a default choice unless there is a compelling reason otherwise.

--- a/decisions/001-using-circleci.md
+++ b/decisions/001-using-circleci.md
@@ -37,9 +37,16 @@ The **default** choice of continuous integration service in the LAA Digital team
 
 ## Consequences
 
+### Adoption
+
 **Existing** LAA repositories using other CI services may continue using them until a change is necessary.
 New jobs and significant changes should migrate to CircleCI.
 
 **New** LAA applications should start with CircleCI as a default choice unless there is a compelling reason otherwise.
+
+### Monitoring
+
+In the case of long job **queues** building up, please contact [`#circleci-users`][circleci-users-slack] for support.
+The people in that group will help with mitigating the delays, if possible.
 
 [circleci-users-slack]: https://mojdt.slack.com/messages/CCSD5F397


### PR DESCRIPTION
## What does this pull request do?

Adds a decision record about using CircleCI.

⏰ I plan to wait until 8 May 2019 noon for feedback.

## Why make these changes?

We (teams in the Legal Aid Agency) have talked about using CircleCI as default, and I would like to capture this decision for further reference and posterity.

## Show me the result

https://github.com/ministryofjustice/laa-architecture-documentation/blob/a6e60209bc83e18ebc1eb503faf1f4421da59048/decisions/001-using-circleci.md