### PR TITLE
Add coherent application deployments proposal

### DIFF
--- a/decisions/002-atomic-deployments.md
+++ b/decisions/002-atomic-deployments.md
@@ -1,0 +1,66 @@
+# ADR-002: Atomic application deployments
+
+## Status
+
+Proposed
+
+## Context
+
+In the Legal Aid Agency (LAA), we have many older applications.
+These applications currently follow **one or more** of the following practices:
+
+### Releases are patches
+
+Most of these applications have one or more of the following:
+
+- Release scripts: scripts that we execute during the release. These files refer to code files in the repository.
+- Release instructions: Word documents or plaintext instructions for the Database Administrator (DBA) on what to do during the release.
+
+We add these for every release.
+
+### Duplicated files
+
+Sometimes files are duplicated and referred to individually in releases, following this pattern:
+
+```
+ebiz/db_install/release_01.ksh
+# refers ebiz/aol/lookups/name_of_lookup.ldt
+
+ebiz/db_install/release_02.ksh
+# refers ebiz/aol/lookups/name_of_lookup_2.ldt
+```
+
+These files refer to the same entity, which makes it harder to see which one is the "current" version.
+
+### Inconsistent deployments
+
+We sometimes skip releasing to a specific environment if it is unavailable, which leads to a drift of functionality between the environments.
+
+### Refresh process
+
+To counter the drift of code and data, we periodically "refresh" the environments. In most cases, this means taking a
+copy of **production**, anonymising it if necessary and restoring that on the target environment.
+
+However, we sometimes refresh from an older copy of production, which produces the same symptoms as "inconsistent
+deployments".
+
+### Manual releases
+
+We manually copy the release-related files to the target server. We do not use unique identifiers similar to a
+git commit SHA to **match** the applied changes against the codebase.
+
+### Summary
+
+It is difficult to answer the following questions:
+
+- What runs on the environment? (After refresh, were all patches applied?)
+- What do I need to do to get to the latest `master` version of the code? (What patches do I need to apply?)
+- What do I need to do to get to a specific version of the code? (What patches have to be rolled back?)
+
+## Proposal
+
+TBC; identify git sha for deployments; establish an easy way to roll forward
+
+## Consequences
+
+TBC

--- a/decisions/002-atomic-deployments.md
+++ b/decisions/002-atomic-deployments.md
@@ -61,6 +61,13 @@ It is difficult to answer the following questions:
 
 TBC; identify git sha for deployments; establish an easy way to roll forward
 
+### Related literature
+
+- Immutable architecture?
+- [Build, release, run (12factor.net)](https://12factor.net/build-release-run)
+- [Schema migration (wikipedia.org)](https://en.wikipedia.org/wiki/Schema_migration)
+- [Evolutionary Database Design (martinfowler.com)](https://martinfowler.com/articles/evodb.html)
+
 ## Consequences
 
 TBC

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -75,6 +75,7 @@ We propose that each service **must** work towards satisfying the following chec
 - Changes to source code resulting in application behaviour change, for example, Java, Ruby, PL/SQL, HTML, CSS, and similar.
 - Changes to categorical data which the users cannot change, for example, a list of allowed codes.
 - Changes to schemas or structures, for example, database schema migrations for relational databases.
+    - :memo: See also: [ADR-042: Database pipeline][hosting-adr-42] in the [hosting architectural decisions][hosting-adrs].
 
 "Changes" do *not* typically include:
 
@@ -135,3 +136,6 @@ We created a [demo checklist spreadsheet](https://docs.google.com/spreadsheets/d
   to prepare environments for testing or demos.
 - After adhering to the above checklist, we can deploy subsequent revisions of our applications on-demand and
   we can expect the deployed behaviour to match the revision's behaviour, leaving no surprises.
+
+[hosting-adr-42]: https://github.com/ministryofjustice/laa-hosting-architectural-decisions/blob/master/doc/adr/0042-database-pipeline.md
+[hosting-adrs]: https://github.com/ministryofjustice/laa-hosting-architectural-decisions

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -9,7 +9,9 @@ Proposed
 In the Legal Aid Agency (LAA), we have many older applications.
 These applications currently follow **one or more** of the following practices:
 
-### Releases are patches
+### Symptoms of discontinuous deployments
+
+#### Releases are patches
 
 Most of these applications have one or more of the following:
 
@@ -19,7 +21,7 @@ Most of these applications have one or more of the following:
 
 We add these for every release.
 
-### Duplicated files
+#### Copying as version control
 
 Sometimes files are duplicated and referred to individually in releases, following this pattern:
 
@@ -33,11 +35,11 @@ ebiz/db_install/release_02.ksh
 
 These files refer to the same entity, which makes it harder to see which one is the "current" version.
 
-### Inconsistent deployments
+#### Inconsistent deployments
 
 We sometimes skip releasing to a specific environment if it is unavailable, which leads to a drift of functionality between the environments.
 
-### Refresh process
+#### Refresh process
 
 To counter the drift of code and data, we periodically "refresh" the environments. In most cases, this means taking a
 copy of **production**, anonymising it if necessary and restoring that on the target environment.
@@ -45,28 +47,51 @@ copy of **production**, anonymising it if necessary and restoring that on the ta
 However, we sometimes refresh from an older copy of production, which produces the same symptoms as "inconsistent
 deployments".
 
-### Manual releases
+#### Manual releases
 
 We manually copy the release-related files to the target server. We do not use unique identifiers similar to a
 git commit SHA to **match** the applied changes against the codebase.
 
-### Summary
+### State awareness in environments
 
 It is difficult to answer the following questions:
 
-- What runs on the environment? (After refresh, were all patches applied?)
-- What do I need to do to get to the latest `master` version of the code? (What patches do I need to apply?)
-- What do I need to do to get to a specific version of the code? (What patches have to be rolled back?)
+- What runs on the environment? &RightArrowLeftArrow; Which revision of the repository is deployed?
+- What do I need to do to get to the latest `master` version of the code?
+- What do I need to do to get to a specific version of the code?
 
 ## Proposal
 
 We propose that each service **must** work towards satisfying the following checklist for **non-development** environments:
 
-| Check | Expressed as a negation |
-| --- | --- |
-| We can **only** apply [changes](#defining-changes) by putting them through version control. | [Changes](#defining-changes) **cannot** be made without version control updates. |
-| [Changes](#defining-changes) can be applied **without** the applying user logging into the application servers or databases. | Users **cannot** log in application servers or databases to apply [changes](#defining-changes). |
-| [Changes](#defining-changes) are applied or rolled back together. | It is impossible to deploy a version and have artefacts from earlier deployments still alive. |
+### Check 1: Version control
+
+We can **only** apply [changes](#defining-changes) by putting them through version control.
+&RightArrowLeftArrow; [Changes](#defining-changes) **cannot** be made without version control updates.
+
+- More frequent use of version control resolves [Copying as version control](#copying-as-version-control).
+- If everything is in git, it enables us to refer to versions of the application by the [git commit SHA][git-sha].
+
+### Check 2: Automation
+
+[Changes](#defining-changes) can be applied **without** the applying user logging into the application servers or databases.
+&RightArrowLeftArrow; Users **cannot** log in application servers or databases to apply [changes](#defining-changes).
+
+- Resolves [Manual releases](#manual-releases) by preventing manual deployments.
+- Opens the possibility to resolve [Inconsistent deployments](#inconsistent-deployments) by enabling pipelines.
+
+### Check 3: Coherence
+
+[Changes](#defining-changes) are applied or rolled back together.
+&RightArrowLeftArrow; It is impossible to deploy a version and have artefacts from earlier deployments still alive.
+
+- Resolves [Releases are patches](#releases-are-patches) by treating code as a whole.
+- Contributes to resolving [Inconsistent deployments](#inconsistent-deployments) by enabling pipelines.
+
+### Effect of these checks
+
+Automated, coherent, version-control-driven deployments will enable us to answer all the questions in
+[State awareness in environments](#state-awareness-in-environments).
 
 ### Defining "changes"
 
@@ -134,8 +159,9 @@ We created a [demo checklist spreadsheet](https://docs.google.com/spreadsheets/d
 - We can deploy our applications with automation tools, ensuring we can reliably release any time.
 - We can answer "What version of this application is currently running on this environment?", making it easier
   to prepare environments for testing or demos.
-- After adhering to the above checklist, we can deploy subsequent revisions of our applications on-demand and
+- After adhering to the above checklist, we can deploy subsequent revisions of our applications on-demand, and
   we can expect the deployed behaviour to match the revision's behaviour, leaving no surprises.
 
 [hosting-adr-42]: https://github.com/ministryofjustice/laa-hosting-architectural-decisions/blob/master/doc/adr/0042-database-pipeline.md
 [hosting-adrs]: https://github.com/ministryofjustice/laa-hosting-architectural-decisions
+[git-sha]: https://git-scm.com/book/en/v1/Getting-Started-Git-Basics#Git-Has-Integrity

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -23,17 +23,24 @@ We add these for every release.
 
 #### Copying as version control
 
-Sometimes files are duplicated and referred to individually in releases, following this pattern:
+We have files defining an entity (procedure, seed data) in version control that were duplicated and changed in the new file:
 
 ```
-ebiz/db_install/release_01.ksh
-# refers ebiz/aol/lookups/name_of_lookup.ldt
-
-ebiz/db_install/release_02.ksh
-# refers ebiz/aol/lookups/name_of_lookup_2.ldt
+-rw-r--r--  1 user  staff   1.6M  <redacted>_phase1.sql
+-rw-r--r--  1 user  staff   1.6M  <redacted>_Phase1.1.sql
+-rw-r--r--  1 user  staff   1.6M  <redacted>_phase1.2.sql
+-rw-r--r--  1 user  staff   1.6M  <redacted>_phase1.3.sql
+-rw-r--r--  1 user  staff   1.7M  <redacted>_phase1.4.sql
+-rw-r--r--  1 user  staff   1.7M  <redacted>_phase1.41.sql
+-rw-r--r--  1 user  staff   1.9M  <redacted>_phase1.5.sql
+-rw-r--r--  1 user  staff   2.0M  <redacted>_phase1.61.sql
+-rw-r--r--  1 user  staff   1.9M  <redacted>_phase1.7.sql
+-rw-r--r--  1 user  staff   1.9M  <redacted>_phase1.8.sql
 ```
 
-These files refer to the same entity, which makes it harder to see which one is the "current" version.
+These files are referred in separate installation scripts or release instructions.
+
+It's sufficient to only change the original file as the history is retained as part of the version control system.
 
 #### Inconsistent deployments
 

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -60,15 +60,13 @@ It is difficult to answer the following questions:
 
 ## Proposal
 
-:raising_hand: **Note**: Please see the definition of "changes" below.
+We propose the following checklist for **non-development** environments:
 
-We propose the following checklist:
-
-| Item | Item reversed |
+| Item | Expressed as a negation |
 | --- | --- |
-| Outside development environments, changes can **only** be applied by putting them through version control. | Changes **cannot** be made to non-development environments without version control updates. |
-| [wip] to capture "deployment action outside the servers"<br/>Outside development environments, changes can be applied **without** the applying user logging into the servers. | Users **cannot** log in to application servers or databases to apply changes. |
-| [wip] to capture "git sha -> build -> release"<br/>Outside development environments, changes can **only** be applied from a [thing] associated with a git commit. | **Every** change can be tied back to a git commit. |
+| [Changes](#defining-changes) can **only** be applied by putting them through version control. | [Changes](#defining-changes) **cannot** be made without version control updates. |
+| [Changes](#defining-changes) can be applied **without** the applying user logging into the application servers or databases. | Users **cannot** log in application servers or databases to apply [changes](#defining-changes). |
+| [wip] something to capture the benefits of builds/artifacts, to represent the entire application (we deploy everything, not patches)
 
 ### Defining "changes"
 

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -60,7 +60,31 @@ It is difficult to answer the following questions:
 
 ## Proposal
 
-TBC; identify git sha for deployments; establish an easy way to roll forward
+:raising_hand: **Note**: Please see the definition of "changes" below.
+
+We propose the following checklist:
+
+| Item | Item reversed |
+| --- | --- |
+| Outside development environments, changes can **only** be applied by putting them through version control. | Changes **cannot** be made to non-development environments without version control updates. |
+| [wip] to capture "deployment action outside the servers"<br/>Outside development environments, changes can be applied **without** the applying user logging into the servers. | Users **cannot** log in to application servers or databases to apply changes. |
+| [wip] to capture "git sha -> build -> release"<br/>Outside development environments, changes can **only** be applied from a [thing] associated with a git commit. | **Every** change can be tied back to a git commit. |
+
+### Defining "changes"
+
+"Changes" include **all** kinds of **typical** **code** changes.
+Data is outside the scope of this document.
+
+For practical purposes, we recommend treating the different types of changes as different work.
+The steps to apply Java changes are different than applying PL/SQL changes.
+
+### Assessment
+
+Teams should
+
+- assess what kinds of "changes" do they have for an application;
+- assess where they are on this checklist;
+- and collaborate with their product owner and operations team to create a way forward.
 
 ### Related literature
 

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -64,8 +64,22 @@ TBC; identify git sha for deployments; establish an easy way to roll forward
 ### Related literature
 
 - [Build, release, run (12factor.net)](https://12factor.net/build-release-run)
-- [Schema migration (wikipedia.org)](https://en.wikipedia.org/wiki/Schema_migration)
+  > The twelve-factor app uses strict separation between the build, release, and run stages.
+  >
+  > For example, it is impossible to make changes to the code at runtime, since there is no way
+  > to propagate those changes back to the build stage.
+- [DevOps Culture (martinfowler.com)](https://martinfowler.com/bliki/DevOpsCulture.html)
+  > If a development team shares the responsibility of looking after a system over the course of its lifetime,
+  > they are able to share the operations staff’s pain and so identify ways to simplify deployment and maintenance
+- [Continuous Delivery (martinfowler.com)](https://martinfowler.com/bliki/ContinuousDelivery.html)
+  > You’re doing continuous delivery when [...] you can perform push-button deployments of any version of the
+  > software to any environment on demand
 - [Evolutionary Database Design (martinfowler.com)](https://martinfowler.com/articles/evodb.html)
+  > Developers continuously integrate database changes
+  >
+  > [...] The steps above are just about treating the database code as another piece of source code.
+  > As such the database code - DDL, DML, Data, views, triggers, stored procedures - is kept under
+  > configuration management in the same way as the source code.
 
 ## Consequences
 

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -129,4 +129,8 @@ We created a [demo checklist spreadsheet](https://docs.google.com/spreadsheets/d
 
 ## Consequences
 
-TBC
+- We can deploy our applications as a whole with automation tools, ensuring we can reliably release any time.
+- We can answer "What version of this application is currently running on this environment?", making it easier
+  to prepare environments for testing or demos.
+- After adhering to the above checklist, we can deploy subsequent revisions of our applications on-demand and
+  we can expect the deployed behaviour to match the revision's behaviour.

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -49,10 +49,15 @@ We sometimes skip releasing to a specific environment if it is unavailable, whic
 #### Refresh process
 
 To counter the drift of code and data, we periodically "refresh" the environments. In most cases, this means taking a
-copy of **production**, anonymising it if necessary and restoring that on the target environment.
+copy of **production** (configuration, code, data, indexes, views, triggers, functions, procedures and packages).
 
-However, we sometimes refresh from an older copy of production, which produces the same symptoms as "inconsistent
-deployments".
+The copy of code (including database functions and procedures) is necessary to resolve the effect of long-term
+[Releases are patches](#releases-are-patches), because we are unable to restore production functionality otherwise.
+
+We anonymise the production data if necessary and make the data available on the target environment.
+
+Sometimes we refresh from an older copy of production, which produces the same symptoms as
+[Inconsistent deployments](#inconsistent-deployments).
 
 #### Manual releases
 

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -72,8 +72,16 @@ We propose the following checklist:
 
 ### Defining "changes"
 
-"Changes" include **all** kinds of **typical** **code** changes.
-Data is outside the scope of this document.
+"Changes" typically include:
+
+- Changes to source code resulting in application behaviour change, for example, Java, Ruby, PL/SQL, HTML, CSS and so on.
+- Changes to categorical data which the users cannot change, for example, a list of allowed codes.
+- Changes to schemas or structures, for example, database schema migrations for relational databases.
+
+"Changes" do *not* typically include:
+
+- Corrections to user-created production data.
+- Additions to production data that could be created by users.
 
 For practical purposes, we recommend treating the different types of changes as different work.
 The steps to apply Java changes are different than applying PL/SQL changes.

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -99,18 +99,31 @@ Teams should
   >
   > For example, it is impossible to make changes to the code at runtime, since there is no way
   > to propagate those changes back to the build stage.
+
+- [Release It! 2nd Edition](https://pragprog.com/book/mnee2/release-it-second-edition), Chapter 8, "Code"
+  > [...] making sure that you know exactly what goes into the code on the instance.
+  > It is vital to establish a strong “chain of custody” that stretches from the developer through to the
+  > production instance. It must be impossible for an unauthorized party to sneak code into your system.
+
 - [DevOps Culture (martinfowler.com)](https://martinfowler.com/bliki/DevOpsCulture.html)
   > If a development team shares the responsibility of looking after a system over the course of its lifetime,
   > they are able to share the operations staff’s pain and so identify ways to simplify deployment and maintenance
+
 - [Continuous Delivery (martinfowler.com)](https://martinfowler.com/bliki/ContinuousDelivery.html)
   > You’re doing continuous delivery when [...] you can perform push-button deployments of any version of the
   > software to any environment on demand
+
 - [Evolutionary Database Design (martinfowler.com)](https://martinfowler.com/articles/evodb.html)
   > Developers continuously integrate database changes
   >
   > [...] The steps above are just about treating the database code as another piece of source code.
   > As such the database code - DDL, DML, Data, views, triggers, stored procedures - is kept under
   > configuration management in the same way as the source code.
+
+- [97 Things Every Software Architect Should Know](https://www.amazon.co.uk/Things-Every-Software-Architect-Should/dp/059652269X), Chapter 86, "Control the Data, Not Just the Code"
+  > You need to be able to build the entire application, including the database, as one unit.
+  > Make data and schema management a seamless part of your automated build and testing process early on and
+  > include an undo button; it will pay large dividends.
 
 ## Consequences
 

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -77,6 +77,7 @@ We can **only** apply [changes](#defining-changes) by putting them through versi
 [Changes](#defining-changes) can be applied **without** the applying user logging into the application servers or databases.
 &RightArrowLeftArrow; Users **cannot** log in application servers or databases to apply [changes](#defining-changes).
 
+- We want to avoid the possibility to do manual changes as part of typical releases.
 - Resolves [Manual releases](#manual-releases) by preventing manual deployments.
 - Opens the possibility to resolve [Inconsistent deployments](#inconsistent-deployments) by enabling pipelines.
 

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -129,8 +129,9 @@ We created a [demo checklist spreadsheet](https://docs.google.com/spreadsheets/d
 
 ## Consequences
 
-- We can deploy our applications as a whole with automation tools, ensuring we can reliably release any time.
+- We no longer need to refresh an environment from production; our deployment process can replicate a known state.
+- We can deploy our applications with automation tools, ensuring we can reliably release any time.
 - We can answer "What version of this application is currently running on this environment?", making it easier
   to prepare environments for testing or demos.
 - After adhering to the above checklist, we can deploy subsequent revisions of our applications on-demand and
-  we can expect the deployed behaviour to match the revision's behaviour.
+  we can expect the deployed behaviour to match the revision's behaviour, leaving no surprises.

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -63,7 +63,7 @@ git commit SHA to **match** the applied changes against the codebase.
 
 It is difficult to answer the following questions:
 
-- What runs on the environment? &RightArrowLeftArrow; Which revision of the repository is deployed?
+- What version of this application is currently running on this environment?
 - What do I need to do to get to the latest `master` version of the code?
 - What do I need to do to get to a specific version of the code?
 
@@ -95,11 +95,6 @@ We can **only** apply [changes](#defining-changes) by putting them through versi
 
 - Resolves [Releases are patches](#releases-are-patches) by treating code as a whole.
 - Contributes to resolving [Inconsistent deployments](#inconsistent-deployments) by enabling pipelines.
-
-### Effect of these checks
-
-Automated, coherent, version-control-driven deployments will enable us to answer all the questions in
-[State awareness in environments](#state-awareness-in-environments).
 
 ### Defining "changes"
 
@@ -163,12 +158,13 @@ We created a [demo checklist spreadsheet](https://docs.google.com/spreadsheets/d
 
 ## Consequences
 
-- We no longer need to refresh an environment from production; our deployment process can replicate a known state.
+- We no longer need to [refresh](#refresh-process) an environment from production;
+  our deployment process can replicate a known state. (We only need to restore production-like data, if needed.)
 - We can deploy our applications with automation tools, ensuring we can reliably release any time.
-- We can answer "What version of this application is currently running on this environment?", making it easier
+- We can answer the questions in [State awareness in environments](#state-awareness-in-environments), making it easier
   to prepare environments for testing or demos.
-- After adhering to the above checklist, we can deploy subsequent revisions of our applications on-demand, and
-  we can expect the deployed behaviour to match the revision's behaviour, leaving no surprises.
+- We can deploy our applications on-demand, and we can expect the deployed behaviour to exactly match the revision's
+  behaviour, leaving no surprises.
 
 [hosting-adr-42]: https://github.com/ministryofjustice/laa-hosting-architectural-decisions/blob/master/doc/adr/0042-database-pipeline.md
 [hosting-adrs]: https://github.com/ministryofjustice/laa-hosting-architectural-decisions

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -66,7 +66,7 @@ We propose the following checklist for **non-development** environments:
 | --- | --- |
 | [Changes](#defining-changes) can **only** be applied by putting them through version control. | [Changes](#defining-changes) **cannot** be made without version control updates. |
 | [Changes](#defining-changes) can be applied **without** the applying user logging into the application servers or databases. | Users **cannot** log in application servers or databases to apply [changes](#defining-changes). |
-| [wip] something to capture the benefits of builds/artifacts, to represent the entire application (we deploy everything, not patches)
+| [Changes](#defining-changes) are applied or rolled back together. | It is impossible to deploy a version and have artifacts from earlier deployments still alive. |
 
 ### Defining "changes"
 

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -109,6 +109,8 @@ We can **only** apply [changes](#defining-changes) by putting them through versi
 - Changes to categorical data which the users cannot change, for example, a list of allowed codes.
 - Changes to schemas or structures, for example, database schema migrations for relational databases.
     - :memo: See also: [ADR-042: Database pipeline][hosting-adr-42] in the [hosting architectural decisions][hosting-adrs].
+- [Changes to runtime configuration](https://12factor.net/config), either secrets or public.
+- [Changes to infrastructure][IaC].
 
 "Changes" do *not* typically include:
 
@@ -176,6 +178,7 @@ The Legal Aid Agency (LAA) architecture community will support applications movi
 - Joining the **hands-on** work as there _is_ a dedicated architect for every LAA service area.
   We will collate feedback and evolve this document.
 
+[IaC]: https://www.thoughtworks.com/insights/blog/infrastructure-code-reason-smile
 [hosting-adr-42]: https://github.com/ministryofjustice/laa-hosting-architectural-decisions/blob/master/doc/adr/0042-database-pipeline.md
 [hosting-adrs]: https://github.com/ministryofjustice/laa-hosting-architectural-decisions
 [git-sha]: https://git-scm.com/book/en/v1/Getting-Started-Git-Basics#Git-Has-Integrity

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -1,4 +1,4 @@
-# ADR-002: Atomic application deployments
+# ADR-002: Coherent application deployments
 
 ## Status
 
@@ -63,7 +63,6 @@ TBC; identify git sha for deployments; establish an easy way to roll forward
 
 ### Related literature
 
-- Immutable architecture?
 - [Build, release, run (12factor.net)](https://12factor.net/build-release-run)
 - [Schema migration (wikipedia.org)](https://en.wikipedia.org/wiki/Schema_migration)
 - [Evolutionary Database Design (martinfowler.com)](https://martinfowler.com/articles/evodb.html)

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -115,9 +115,6 @@ We can **only** apply [changes](#defining-changes) by putting them through versi
 - Corrections to user-created production data.
 - Additions to production data that could be created by users.
 
-For practical purposes, we recommend treating the different types of changes as different work.
-The steps to apply Java changes are different than applying PL/SQL changes.
-
 ### Example assessment
 
 To measure the necessary changes required, teams could

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -13,7 +13,8 @@ These applications currently follow **one or more** of the following practices:
 
 Most of these applications have one or more of the following:
 
-- Release scripts: scripts that we execute during the release. These files refer to code files in the repository.
+- Release scripts: scripts that we execute during the release. These files refer to database code files (Oracle PL/SQL (`.pks`, `.pkb`),
+  Oracle Loader DaTa (`.ldt`), etc.) in the repository.
 - Release instructions: Word documents or plaintext instructions for the Database Administrator (DBA) on what to do during the release.
 
 We add these for every release.

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -92,6 +92,8 @@ Teams should
 - assess where they are on this checklist;
 - and collaborate with their product owner and operations team to create a way forward.
 
+We created a [demo checklist spreadsheet](https://docs.google.com/spreadsheets/d/1oveCM853tk602N6-BYaxRgUV8eB2jfUnkQmaBYzbXog/edit?usp=sharing) as a starting point, in case it's useful.
+
 ### Related literature
 
 - [Build, release, run (12factor.net)](https://12factor.net/build-release-run)

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -160,8 +160,7 @@ We created a [demo checklist spreadsheet](https://docs.google.com/spreadsheets/d
 
 ## Consequences
 
-- We no longer need to [refresh](#refresh-process) an environment from production;
-  our deployment process can replicate a known state. (We only need to restore production-like data, if needed.)
+- We only need to [refresh](#refresh-process) production-like **data**, if needed. We no longer need **code** refreshes.
 - We can deploy our applications with automation tools, ensuring we can reliably release any time.
 - We can answer the questions in [State awareness in environments](#state-awareness-in-environments), making it easier
   to prepare environments for testing or demos.

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -167,6 +167,16 @@ We created a [demo checklist spreadsheet](https://docs.google.com/spreadsheets/d
 - We can deploy our applications on-demand, and we can expect the deployed behaviour to exactly match the revision's
   behaviour, leaving no surprises.
 
+### Support
+
+The Legal Aid Agency (LAA) architecture community will support applications moving to conform to this checklist by:
+
+- Setting up a Slack channel, [`#ask-laa-architects`][support-channel], where people can discuss and debate and offer
+  feedback.
+- Joining the **hands-on** work as there _is_ a dedicated architect for every LAA service area.
+  We will collate feedback and evolve this document.
+
 [hosting-adr-42]: https://github.com/ministryofjustice/laa-hosting-architectural-decisions/blob/master/doc/adr/0042-database-pipeline.md
 [hosting-adrs]: https://github.com/ministryofjustice/laa-hosting-architectural-decisions
 [git-sha]: https://git-scm.com/book/en/v1/Getting-Started-Git-Basics#Git-Has-Integrity
+[support-channel]: https://mojdt.slack.com/messages/CM9JJ1E87

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -61,8 +61,11 @@ Sometimes we refresh from an older copy of production, which produces the same s
 
 #### Manual releases
 
-We manually copy the release-related files to the target server. We do not use unique identifiers similar to a
-git commit SHA to **match** the applied changes against the codebase.
+We manually copy the release-related files to the target server and manually apply the changes.
+
+Usually, we have to wait for someone with enough privileges to be available to do the release.
+
+We do not use unique identifiers similar to a git commit SHA to **match** the applied changes against the codebase.
 
 ### State awareness in environments
 

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -13,8 +13,8 @@ These applications currently follow **one or more** of the following practices:
 
 Most of these applications have one or more of the following:
 
-- Release scripts: scripts that we execute during the release. These files refer to database code files (Oracle PL/SQL (`.pks`, `.pkb`),
-  Oracle Loader DaTa (`.ldt`), etc.) in the repository.
+- Release scripts: scripts that we execute during the release. These files, in turn, refer to database code files (Oracle PL/SQL (`.pks`, `.pkb`),
+  Oracle Loader DaTa (`.ldt`) and others) in the repository.
 - Release instructions: Word documents or plaintext instructions for the Database Administrator (DBA) on what to do during the release.
 
 We add these for every release.
@@ -64,15 +64,15 @@ We propose the following checklist for **non-development** environments:
 
 | Item | Expressed as a negation |
 | --- | --- |
-| [Changes](#defining-changes) can **only** be applied by putting them through version control. | [Changes](#defining-changes) **cannot** be made without version control updates. |
+| We can **only** apply [changes](#defining-changes) by putting them through version control. | [Changes](#defining-changes) **cannot** be made without version control updates. |
 | [Changes](#defining-changes) can be applied **without** the applying user logging into the application servers or databases. | Users **cannot** log in application servers or databases to apply [changes](#defining-changes). |
-| [Changes](#defining-changes) are applied or rolled back together. | It is impossible to deploy a version and have artifacts from earlier deployments still alive. |
+| [Changes](#defining-changes) are applied or rolled back together. | It is impossible to deploy a version and have artefacts from earlier deployments still alive. |
 
 ### Defining "changes"
 
 "Changes" typically include:
 
-- Changes to source code resulting in application behaviour change, for example, Java, Ruby, PL/SQL, HTML, CSS and so on.
+- Changes to source code resulting in application behaviour change, for example, Java, Ruby, PL/SQL, HTML, CSS, and similar.
 - Changes to categorical data which the users cannot change, for example, a list of allowed codes.
 - Changes to schemas or structures, for example, database schema migrations for relational databases.
 
@@ -90,7 +90,7 @@ Teams should
 
 - assess what kinds of "changes" do they have for an application;
 - assess where they are on this checklist;
-- and collaborate with their product owner and operations team to create a way forward.
+- collaborate with their product owner and operations team to create a way forward.
 
 We created a [demo checklist spreadsheet](https://docs.google.com/spreadsheets/d/1oveCM853tk602N6-BYaxRgUV8eB2jfUnkQmaBYzbXog/edit?usp=sharing) as a starting point, in case it's useful.
 
@@ -122,7 +122,7 @@ We created a [demo checklist spreadsheet](https://docs.google.com/spreadsheets/d
   > As such the database code - DDL, DML, Data, views, triggers, stored procedures - is kept under
   > configuration management in the same way as the source code.
 
-- [97 Things Every Software Architect Should Know](https://www.amazon.co.uk/Things-Every-Software-Architect-Should/dp/059652269X), Chapter 86, "Control the Data, Not Just the Code"
+- [97 Things Every Software Architect Should Know](https://www.amazon.co.uk/Things-Every-Software-Architect-Should/dp/059652269X), Chapter 86, "Control the Data, Not Just the Code".
   > You need to be able to build the entire application, including the database, as one unit.
   > Make data and schema management a seamless part of your automated build and testing process early on and
   > include an undo button; it will pay large dividends.

--- a/decisions/002-coherent-deployments.md
+++ b/decisions/002-coherent-deployments.md
@@ -60,9 +60,9 @@ It is difficult to answer the following questions:
 
 ## Proposal
 
-We propose the following checklist for **non-development** environments:
+We propose that each service **must** work towards satisfying the following checklist for **non-development** environments:
 
-| Item | Expressed as a negation |
+| Check | Expressed as a negation |
 | --- | --- |
 | We can **only** apply [changes](#defining-changes) by putting them through version control. | [Changes](#defining-changes) **cannot** be made without version control updates. |
 | [Changes](#defining-changes) can be applied **without** the applying user logging into the application servers or databases. | Users **cannot** log in application servers or databases to apply [changes](#defining-changes). |
@@ -84,9 +84,9 @@ We propose the following checklist for **non-development** environments:
 For practical purposes, we recommend treating the different types of changes as different work.
 The steps to apply Java changes are different than applying PL/SQL changes.
 
-### Assessment
+### Example assessment
 
-Teams should
+To measure the necessary changes required, teams could
 
 - assess what kinds of "changes" do they have for an application;
 - assess where they are on this checklist;


### PR DESCRIPTION
## What does this pull request do?

Adds a proposed Architecture Decision Record (ADR) about how we treat our application deployments.

## Why make these changes?

We work in an environment where older and newer practices coexist, and there is currently no written Legal Aid Agency guidance on the desired future state.

## Show me the result

https://github.com/ministryofjustice/laa-architecture-documentation/blob/adr-application-releases/decisions/002-coherent-deployments.md

## History

📝 The commit history has more detailed comments.

- 12/07/2019: Opened draft pull request to gather feedback on the context statement. I'm keen to collect literature that talks about why atomic deployments are useful.
- 16/07/2019: Renamed "atomic deployments" to "coherent deployments" to capture that the document is focusing on "forming a whole".
- 16/07/2019: First attempt at the proposal.
- 17/07/2019: Expand the "changes" definition, proposal and literature sections.
- 18/07/2019: Finish up proposal section and add the first consequence section. Add [demo checklist](https://docs.google.com/spreadsheets/d/1oveCM853tk602N6-BYaxRgUV8eB2jfUnkQmaBYzbXog/edit?usp=sharing) (public link).

    ![Screenshot from 2019-07-18 17-33-58](https://user-images.githubusercontent.com/1526295/61475240-4762a300-a982-11e9-8abd-0282c1cdce32.png)

- 19/07/2019: Ready for review.
- 06/08/2019: Processing feedback.